### PR TITLE
Potential fix for code scanning alert no. 4: Unsafe jQuery plugin

### DIFF
--- a/out/js/util.js
+++ b/out/js/util.js
@@ -95,10 +95,28 @@
 			}, userConfig);
 
 			// Expand "target" if it's not a jQuery object already.
-				// if (typeof config.target != 'jQuery')
-				// 	config.target = $(config.target);
-				if (typeof config.target !== 'object' || !(config.target instanceof $)) {
-				  config.target = $(config.target).first();  // or sanitize selector
+				// If target is already a jQuery object, leave it as-is.
+				if (config.target instanceof $) {
+					// do nothing
+				}
+				else if (config.target && (config.target.nodeType === 1 || config.target === window || config.target === document)) {
+					// DOM element, window, or document: wrap in jQuery.
+					config.target = $(config.target);
+				}
+				else if (typeof config.target === 'string') {
+					var targetStr = config.target.trim();
+					// If the string looks like HTML, do NOT pass it to $() to avoid XSS.
+					if (targetStr.charAt(0) === '<') {
+						// Fallback to the panel element itself as the target.
+						config.target = $this;
+					} else {
+						// Treat as a selector; use the first match.
+						config.target = $(targetStr).first();
+					}
+				}
+				else {
+					// Unsupported type: fallback to the panel element.
+					config.target = $this;
 				}
 		// Panel.
 


### PR DESCRIPTION
Potential fix for [https://github.com/raimonvibe/website-editorial-eu/security/code-scanning/4](https://github.com/raimonvibe/website-editorial-eu/security/code-scanning/4)

In general, the fix is to ensure that the `target` option, when not already a jQuery object or DOM element, is treated only as a selector (or rejected), not as arbitrary HTML. That means we should avoid passing unvalidated attacker-controlled strings directly to `$()` in a way that jQuery can interpret as HTML (strings starting with `<`). A minimal-hardening approach is to normalize the type of `config.target` and explicitly reject or sanitize strings that look like HTML before calling `$()`.

Concretely, inside `$.fn.panel`, at the “Expand `target`” section, we will replace the existing type check:

```js
// if (typeof config.target != 'jQuery')
// 	config.target = $(config.target);
// if (typeof config.target !== 'object' || !(config.target instanceof $)) {
//   config.target = $(config.target).first();  // or sanitize selector
// }
```

with logic that:

1. Leaves `config.target` unchanged if it is already a jQuery object.
2. Wraps it in jQuery if it is a DOM element or `window`/`document`.
3. If it is a string, trims it, and:
   - If it starts with `<`, treat it as invalid/unexpected and fall back to `$this` (the panel element) instead of letting jQuery parse it as HTML.
   - Otherwise, treat it as a selector and call `$(selector).first()`.
4. For any other type (number, boolean, etc.), also fall back to `$this`.

This keeps intended functionality (using jQuery object, DOM node, or selector) but removes the XSS risk from HTML strings. No new imports are needed; we only use existing jQuery and plain JS.

The change is localized to the “Expand `target`” region around lines 97–102 in `out/js/util.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
