### PR TITLE
Potential fix for code scanning alert no. 3: Unsafe jQuery plugin

### DIFF
--- a/public/js/util.js
+++ b/public/js/util.js
@@ -95,10 +95,22 @@
 			}, userConfig);
 
 			// Expand "target" if it's not a jQuery object already.
-				// if (typeof config.target != 'jQuery')
-				// 	config.target = $(config.target);
-				if (typeof config.target !== 'object' || !(config.target instanceof $)) {
-				  config.target = $(config.target).first();  // or sanitize selector
+				if (!(config.target instanceof $)) {
+
+					// DOM element or window/document: wrap directly.
+					if (config.target && (config.target.nodeType === 1 || config.target === window || config.target === document)) {
+						config.target = $(config.target);
+					}
+
+					// String: treat strictly as selector, not HTML.
+					else if (typeof config.target === 'string') {
+						config.target = $(document).find(config.target).first();
+					}
+
+					// Fallback: if no valid target resolved, use the panel element itself.
+					if (!config.target || config.target.length === 0) {
+						config.target = $this;
+					}
 				}
 
 		// Panel.


### PR DESCRIPTION
Potential fix for [https://github.com/raimonvibe/website-editorial-eu/security/code-scanning/3](https://github.com/raimonvibe/website-editorial-eu/security/code-scanning/3)

In general, to fix this kind of issue in a jQuery plugin, ensure that user-supplied options used to locate DOM elements are always treated as selectors or elements, never as raw HTML. Instead of calling `$(option)` on an arbitrary string (which jQuery treats as HTML if it starts with `<`), use APIs like `.find()` on a trusted root, or validate that the option is an element/jQuery object and reject or constrain anything else.

For this plugin, the best fix without changing existing behavior is:  
- If `config.target` is already a jQuery object, leave it unchanged.  
- If it is a DOM element or `window`/`document`, wrap it with `$()` as before.  
- If it is a string, treat it strictly as a selector by calling `$(document).find(config.target)`, not `$(config.target)`; this prevents HTML parsing and matches the intention “target element for class”.  
- If no elements are found, fall back to the default `$this` (the panel element) so the plugin continues working but does not create new DOM from untrusted strings.

These changes all belong in the “Expand `target`” block around lines 97–102 in `public/js/util.js`. We do not need new imports or external libraries; we only adjust the logic that normalizes `config.target`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
