### PR TITLE
Potential fix for code scanning alert no. 6: Unsafe jQuery plugin

### DIFF
--- a/out/js/util.js
+++ b/out/js/util.js
@@ -110,8 +110,9 @@
 						// Fallback to the panel element itself as the target.
 						config.target = $this;
 					} else {
-						// Treat as a selector; use the first match.
-						config.target = $(targetStr).first();
+						// Treat as a selector; use the first match. Use $.find so the
+						// string is always interpreted as a selector, not as HTML.
+						config.target = $($.find(targetStr)).first();
 					}
 				}
 				else {


### PR DESCRIPTION
Potential fix for [https://github.com/raimonvibe/website-editorial-eu/security/code-scanning/6](https://github.com/raimonvibe/website-editorial-eu/security/code-scanning/6)

In general, the safest way to fix this class of issue in a jQuery plugin is to avoid passing untrusted strings directly to `$()` where jQuery might treat them as HTML. Instead, ensure that such strings are only ever used as selectors via `document.querySelectorAll`, `jQuery.find`, or a similar API that cannot create new DOM nodes from HTML snippets.

In this specific plugin, the problematic line is:

```js
config.target = $(targetStr).first();
```

We want `config.target` to be an element (or set of elements) matched by a CSS selector, not to create arbitrary HTML. To keep functionality unchanged for legitimate selector strings while preventing HTML interpretation, we can route the string through `$.find`, which always treats its argument as a selector against the document and does not parse it as HTML. We should also keep the existing type checks and fallbacks. Concretely:

- Keep the logic for jQuery objects and DOM nodes as‑is.
- Keep the `<`-prefix guard and fallback to `$this` if the string looks like raw HTML.
- Replace `$(targetStr).first()` with `$( $.find(targetStr) ).first();`, which:
  - Uses `$.find` to interpret `targetStr` strictly as a selector.
  - Wraps the resulting node list in `$()` to get a jQuery object.
  - Keeps the behavior of selecting the first matching element.

All changes occur within `out/js/util.js` in the `$.fn.panel` configuration expansion block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
